### PR TITLE
Remove arg0 from isDeviceRooted

### DIFF
--- a/www/rootdetection.js
+++ b/www/rootdetection.js
@@ -1,5 +1,5 @@
 var exec = require('cordova/exec');
 
-exports.isDeviceRooted = function(arg0, success, error) {
-    exec(success, error, "RootDetection", "isDeviceRooted", [arg0]);
+exports.isDeviceRooted = function(success, error) {
+    exec(success, error, "RootDetection", "isDeviceRooted", []);
 };


### PR DESCRIPTION
arg0 is never used in the native code, undocumented and breaks the documented usage.
